### PR TITLE
Stripping spaces from issue fields in equality check, since there see…

### DIFF
--- a/Tools/dqa/issues/cmd.go
+++ b/Tools/dqa/issues/cmd.go
@@ -98,7 +98,7 @@ Multiple log files can be applied:
 						os.Exit(1)
 					}
 
-					if r.Field == issue.Field && r.CheckCode == issue.CheckCode {
+					if strings.Replace(r.Field," ","", -1) == strings.Replace(issue.Field," ","", -1) && r.CheckCode == issue.CheckCode {
 						if r.IsUnresolved() || r.IsPersistent() {
 							conflicts = append(conflicts, &conflict{
 								Index:     i,


### PR DESCRIPTION
…ms to be some location that might add them in (not sure where or when), which is causing persistent issues to be not recognized as matching.